### PR TITLE
URL Cleanup

### DIFF
--- a/src/test/resources/contracts/rest/createHook.groovy
+++ b/src/test/resources/contracts/rest/createHook.groovy
@@ -17,7 +17,7 @@ org.springframework.cloud.contract.spec.Contract.make {
       "*"
     ],
     "config": {
-      "url": "http://github-webhook.cfapps.io/",
+      "url": "https://github-webhook.cfapps.io/",
       "content_type": "json",
       "insecure_ssl": "0"
     },

--- a/src/test/resources/contracts/rest/createIssue.groovy
+++ b/src/test/resources/contracts/rest/createIssue.groovy
@@ -152,7 +152,7 @@ org.springframework.cloud.contract.spec.Contract.make {
     "ssh_url": "git@github.com:spring-cloud/spring-cloud-netflix.git",
     "clone_url": "https://github.com/spring-cloud/spring-cloud-netflix.git",
     "svn_url": "https://github.com/spring-cloud/spring-cloud-netflix",
-    "homepage": "http://cloud.spring.io/spring-cloud-netflix/",
+    "homepage": "https://cloud.spring.io/spring-cloud-netflix/",
     "size": 6756,
     "stargazers_count": 333,
     "watchers_count": 333,

--- a/src/test/resources/github-webhook-input/hook-created.json
+++ b/src/test/resources/github-webhook-input/hook-created.json
@@ -10,7 +10,7 @@
       "*"
     ],
     "config": {
-      "url": "http://github-webhook.cfapps.io/",
+      "url": "https://github-webhook.cfapps.io/",
       "content_type": "json",
       "insecure_ssl": "0"
     },

--- a/src/test/resources/github-webhook-input/issue-created.json
+++ b/src/test/resources/github-webhook-input/issue-created.json
@@ -145,7 +145,7 @@
     "ssh_url": "git@github.com:spring-cloud/spring-cloud-netflix.git",
     "clone_url": "https://github.com/spring-cloud/spring-cloud-netflix.git",
     "svn_url": "https://github.com/spring-cloud/spring-cloud-netflix",
-    "homepage": "http://cloud.spring.io/spring-cloud-netflix/",
+    "homepage": "https://cloud.spring.io/spring-cloud-netflix/",
     "size": 6756,
     "stargazers_count": 333,
     "watchers_count": 333,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://github-webhook.cfapps.io/ (404) with 2 occurrences migrated to:  
  https://github-webhook.cfapps.io/ ([https](https://github-webhook.cfapps.io/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-netflix/ with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/ ([https](https://cloud.spring.io/spring-cloud-netflix/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8761 with 1 occurrences
* http://localhost:8080/ with 1 occurrences